### PR TITLE
increase frame of thumbview gesture recognizers

### DIFF
--- a/MSRangeSlider/MSRangeSlider.m
+++ b/MSRangeSlider/MSRangeSlider.m
@@ -9,7 +9,10 @@
 #import "MSRangeSlider.h"
 
 static CGFloat const kRangeSliderTrackHeight = 2.0f;
-static CGFloat const kRangeSliderDimension = 28.0f;
+static CGFloat const kRangeSliderDimension = 42.0f;
+static CGFloat const kRangeSliderThumbDiameter = 28.0f;
+static CGFloat const kRangeSliderThumbScaledown = kRangeSliderThumbDiameter / kRangeSliderDimension;
+static CGFloat const kRangeSliderScaleEdgeCompensation = (kRangeSliderDimension - kRangeSliderThumbDiameter) / 2;
 
 @interface MSThumbView : UIView
 @property (nonatomic, strong) CALayer *thumbLayer;
@@ -24,6 +27,7 @@ static CGFloat const kRangeSliderDimension = 28.0f;
 
     if (self) {
         self.thumbLayer = [CALayer layer];
+        self.thumbLayer.affineTransform = CGAffineTransformMakeScale(kRangeSliderThumbScaledown, kRangeSliderThumbScaledown);
 
         self.thumbLayer.borderColor = [[UIColor lightGrayColor] colorWithAlphaComponent:.4].CGColor;
         self.thumbLayer.borderWidth = .5;
@@ -218,11 +222,11 @@ static CGFloat const kRangeSliderDimension = 28.0f;
     CGFloat width = CGRectGetWidth(self.bounds);
     CGFloat height = CGRectGetHeight(self.bounds);
 
-    self.trackLayer.bounds = CGRectMake(0, 0, width, kRangeSliderTrackHeight);
+    self.trackLayer.bounds = CGRectMake(0 + kRangeSliderScaleEdgeCompensation, 0, width - 2 * kRangeSliderScaleEdgeCompensation, kRangeSliderTrackHeight);
     self.trackLayer.position = CGPointMake(width / 2, height / 2);
 
-    CGFloat from = CGRectGetMaxX(self.fromThumbView.frame);
-    CGFloat to = CGRectGetMinX(self.toThumbView.frame);
+    CGFloat from = CGRectGetMaxX(self.fromThumbView.frame) - kRangeSliderScaleEdgeCompensation;
+    CGFloat to = CGRectGetMinX(self.toThumbView.frame) + kRangeSliderScaleEdgeCompensation;
 
     [CATransaction begin];
     [CATransaction setValue:(id)kCFBooleanTrue


### PR DESCRIPTION
Hey Max, thanks for publishing this pod to Open Source! I incorporated it into my startup's app this week ( www.getsquad.co ) for one of our settings screen for the age range slider in search. I found it through a Cocoapods.org and chose it from among others for its simplicity and the IB_Designable & IB_Inspectable aspect of it. Nice work!

Because we experienced some difficulty with the thumb sliders being hard to drag due to the area of the gesture recognizers on them, I made some changes in my fork to increase the actual size of the thumbviews while scaling down the CALayer with an affine transform in order to keep it visually the same. I did have to adapt some math on the track frame, though, so there's a little more horizontal padding on the inside of the view now.

You're welcome to have these changes if you like, but please don't feel any pressure to accept them if you disagree with them. Thanks again!
